### PR TITLE
Fix ffmpeg-full version

### DIFF
--- a/org.kde.kphotoalbum.json
+++ b/org.kde.kphotoalbum.json
@@ -26,8 +26,9 @@
     "add-extensions": {
         "org.freedesktop.Platform.ffmpeg-full": {
             "directory": "lib/ffmpeg",
-            "version": "23.08",
-            "add-ld-path": "."
+            "version": "24.08",
+            "add-ld-path": ".",
+            "no-autodownload": false
         }
     },
     "cleanup-commands": [


### PR DESCRIPTION
kde 6.8 is based on freedesktop 24.08. ffmpeg-full version needs to be adjusted for that.

Also make extension autodownloaded which is what most users may expect for full functionality.