### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.kphotoalbum.json
+++ b/org.kde.kphotoalbum.json
@@ -16,12 +16,18 @@
         "--socket=wayland"
     ],
     "cleanup": [
-        "*.a",
-        "*.la",
         "/include",
         "/lib/cmake",
         "/lib/pkgconfig",
-        "/share/man"
+        "/mkspecs",
+        "/share/doc",
+        "/share/man",
+        "/share/qlogging-categories6",
+        "*.la",
+        "*.a"
+    ],
+    "cleanup-commands": [
+        "/app/cleanup-BaseApp.sh"
     ],
     "modules": [
         {


### PR DESCRIPTION
### Total

The installed size reduced from 409 MB to 367 MB.

### Drop /share/doc

KDE apps usually open an external website for help documentation.

This app uses the following page:

https://docs.kde.org/trunk_kf6/en/kphotoalbum/kphotoalbum/index.html

### Drop /share/qlogging-categories

Many projects drop this folder:

https://github.com/search?q=org%3Aflathub+%2Fshare%2Fqlogging-categories&type=code

### Drop mkspecs

Many projects drop this folder:

https://github.com/search?q=org%3Aflathub+mkspecs&type=code